### PR TITLE
Fix devotion content selector to target .wysiwyg wrapper

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -17,7 +17,7 @@ export default function applicationSiteRoutes(app) {
 
             const devotionTitle = $('h1').first().text().trim();
             const date = moment(new Date()).format('Do MMMM YYYY');
-            const devotionContent = $('article.js-scripturize').find('p');
+            const devotionContent = $('article.js-scripturize .wysiwyg').find('p');
 
             const contentArray = devotionContent.map((i, el) => $(el).text().trim()).get();
             const devotionReading = contentArray.splice(0, 1)[0];


### PR DESCRIPTION
## Summary
Updated the CSS selector used to extract devotion content to properly target the `.wysiwyg` wrapper element within the article.

## Changes
- Modified the devotion content selector from `$('article.js-scripturize').find('p')` to `$('article.js-scripturize .wysiwyg').find('p')`
- This ensures the parser correctly identifies paragraph elements within the `.wysiwyg` container, improving content extraction accuracy

## Details
The change adds an additional selector level to navigate through the DOM structure more precisely. By explicitly targeting the `.wysiwyg` class within the article, the scraper will now only extract paragraphs from the intended content wrapper, preventing potential issues with extracting paragraphs from unrelated sections of the article element.

https://claude.ai/code/session_013zgbrJJedm8MEUUZzogBnk