### PR TITLE
Add error handling to devotion API endpoint

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -12,6 +12,13 @@ export default function applicationSiteRoutes(app) {
     app.get('/devotion/get', async function (req, res) {
         try {
             const response = await fetch('https://www.intouchaustralia.org/read/daily-devotions');
+
+            if (!response.ok) {
+                return res.status(502).send({
+                    error: `Failed to fetch devotion from source (HTTP ${response.status})`
+                });
+            }
+
             const html = await response.text();
             const $ = cheerio.load(html);
 
@@ -20,6 +27,13 @@ export default function applicationSiteRoutes(app) {
             const devotionContent = $('article.js-scripturize .wysiwyg').find('p');
 
             const contentArray = devotionContent.map((i, el) => $(el).text().trim()).get();
+
+            if (contentArray.length === 0) {
+                return res.status(502).send({
+                    error: 'Unable to parse devotion content from source — the page structure may have changed'
+                });
+            }
+
             const devotionReading = contentArray.splice(0, 1)[0];
             const bibleInOneYear = contentArray.splice(-1, 1)[0];
 
@@ -28,7 +42,7 @@ export default function applicationSiteRoutes(app) {
                 date: date,
                 reading: devotionReading,
                 content: contentArray,
-                bibleInOneYear: bibleInOneYear.replace(/^Bible in One Year:\s+/i, ''),
+                bibleInOneYear: bibleInOneYear ? bibleInOneYear.replace(/^Bible in One Year:\s+/i, '') : null,
                 credit: "From In Touch Australia (https://www.intouchaustralia.org/read/daily-devotions)"
             };
 
@@ -36,7 +50,9 @@ export default function applicationSiteRoutes(app) {
 
         } catch (error) {
             console.log(error);
-            throw error;
+            return res.status(500).send({
+                error: 'An unexpected error occurred while fetching the devotion'
+            });
         }
     });
 


### PR DESCRIPTION
## Summary
Enhanced the `/devotion/get` endpoint with comprehensive error handling to gracefully handle failures when fetching or parsing devotion content from the external source.

## Key Changes
- **HTTP response validation**: Added check for failed HTTP responses from the source URL, returning a 502 status with descriptive error message
- **Content parsing validation**: Added check to ensure devotion content was successfully parsed from the HTML, returning a 502 status if the page structure appears to have changed
- **Null safety**: Made `bibleInOneYear` field nullable to handle cases where it may not be present in the parsed content
- **Exception handling**: Replaced `throw error` with proper error response (500 status) to prevent unhandled promise rejections and provide consistent API error responses

## Implementation Details
- All error responses follow a consistent JSON format with an `error` field containing a user-friendly message
- HTTP errors from the source return 502 (Bad Gateway) to indicate upstream service issues
- Parsing failures return 502 to indicate the external page structure may have changed
- Unexpected errors return 500 (Internal Server Error)
- Error messages are descriptive enough to aid in debugging while remaining appropriate for API consumers

https://claude.ai/code/session_01527EtmxzPoNe4njkZQQbbX