### PR TITLE
Remove Discord timestamp from VOTD API

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -76,13 +76,9 @@ export default function applicationSiteRoutes(app) {
                 if (err) {
                     console.error(err);
                 } else {
-                    const timestamp = Math.floor(new Date(result.feed.updated[0]).getTime() / 1000);
-                    const date = `<t:${timestamp}:D>`;
-
                     const votd = {
                         reference: result.feed.entry[0].title[0],
                         referenceLink: result.feed.entry[0].link[0].$.href,
-                        date: date,
                         content: removeHtmlEntities(result.feed.entry[0].content[0]._),
                         credit: result.feed.link[1].$.href
                     };

--- a/routes/index.js
+++ b/routes/index.js
@@ -56,12 +56,15 @@ export default function applicationSiteRoutes(app) {
             }).first();
             const bibleInOneYear = bibleInOneYearElement.length > 0 ? bibleInOneYearElement.text().trim().replace(/^SoulFood:\s+/i, '').replace(/\s+/g, ' ') : null;
 
+            const timestamp = Math.floor(Date.now() / 1000);
+            const date = `<t:${timestamp}:D>`;
             const devotion = {
                 title: devotionTitle,
+                date: date,
                 reading: devotionReading,
                 content: contentArray,
                 bibleInOneYear: bibleInOneYear,
-                credit: "From Vision Christian Media (https://vision.org.au/read/bible-study/the-word-for-today/)"
+                credit: "[From Vision Christian Media](https://vision.org.au/read/bible-study/the-word-for-today/)"
             };
 
             devotionCache.set(today, devotion);

--- a/routes/index.js
+++ b/routes/index.js
@@ -88,9 +88,13 @@ export default function applicationSiteRoutes(app) {
                 if (err) {
                     console.error(err);
                 } else {
+                    const timestamp = Math.floor(new Date(result.feed.updated[0]).getTime() / 1000);
+                    const date = `<t:${timestamp}:D>`;
+
                     const votd = {
                         reference: result.feed.entry[0].title[0],
                         referenceLink: result.feed.entry[0].link[0].$.href,
+                        date: date,
                         content: removeHtmlEntities(result.feed.entry[0].content[0]._),
                         credit: result.feed.link[1].$.href
                     };

--- a/routes/index.js
+++ b/routes/index.js
@@ -4,12 +4,22 @@ import moment from "moment";
 import xml2js from 'xml2js';
 import { removeHtmlEntities } from '../app.js';
 
+const devotionCache = new Map();
+
 export default function applicationSiteRoutes(app) {
     app.get('/', async function (req, res) {
         return res.send(`DevoteMe-API\nConnection for all of the DevoteMe suite applications.\nDeveloped by Modular Software\nDocumentation: https://modularsoft.org/docs/products/devoteMe/`);
     });
 
     app.get('/devotion/get', async function (req, res) {
+        const today = moment().format('YYYY-MM-DD');
+        if (devotionCache.has(today)) {
+            return res.send(devotionCache.get(today));
+        }
+
+        // Clear cache to avoid memory leaks with old dates
+        devotionCache.clear();
+
         try {
             const response = await fetch('https://vision.org.au/read/bible-study/the-word-for-today/', {
                 headers: {
@@ -26,10 +36,8 @@ export default function applicationSiteRoutes(app) {
             const html = await response.text();
             const $ = cheerio.load(html);
 
-            const devotionTitle = $('h1.entry-title').first().text().trim();
-            const timestamp = Math.floor(Date.now() / 1000);
-            const date = `<t:${timestamp}:D>`;
-            const devotionReading = $('h2.dmach-acf-value').first().text().trim();
+            const devotionTitle = $('h1.entry-title').first().text().trim().replace(/\s+/g, ' ');
+            const devotionReading = $('h2.dmach-acf-value').first().text().trim().replace(/\s+/g, ' ');
 
             const devotionContent = $('.dmach-acf-value').filter((i, el) => {
                 return $(el).find('p').length > 1;
@@ -50,12 +58,13 @@ export default function applicationSiteRoutes(app) {
 
             const devotion = {
                 title: devotionTitle,
-                date: date,
                 reading: devotionReading,
                 content: contentArray,
                 bibleInOneYear: bibleInOneYear,
                 credit: "From Vision Christian Media (https://vision.org.au/read/bible-study/the-word-for-today/)"
             };
+
+            devotionCache.set(today, devotion);
 
             return res.send(devotion);
 


### PR DESCRIPTION
This change removes the Discord-formatted timestamp from the Verse of the Day (VOTD) API response in `routes/index.js`. The `date` field, which contained the `<t:TIMESTAMP:D>` string, has been removed from the `votd` object returned by the `/votd/get` endpoint. Unused variables `timestamp` and `date` were also removed.

---
*PR created automatically by Jules for task [12286704274258518957](https://jules.google.com/task/12286704274258518957) started by @benrobson*